### PR TITLE
story: cssBaseLine 설정, 테마 설정, 회원가입 페이지 수정

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import { createTheme, CssBaseline, ThemeProvider } from '@mui/material';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
@@ -5,9 +6,53 @@ import './index.css';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+
+const theme = createTheme({
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        '*': {
+          boxSizing: 'border-box',
+          margin: 0,
+          padding: 0
+        },
+        html: {
+          height: '100%',
+          width: '100%'
+        },
+        body: {
+          height: '100%',
+          width: '100%'
+        },
+        '#root': {
+          height: '100%',
+          width: '100%'
+        }
+      }
+    }
+  },
+  palette: {
+    primary: {
+      light: '#757ce8',
+      main: '#3f50b5',
+      dark: '#002884',
+      contrastText: '#fff'
+    },
+    secondary: {
+      light: '#ff7961',
+      main: '#f44336',
+      dark: '#ba000d',
+      contrastText: '#000'
+    }
+  }
+});
+
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );
 

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -10,7 +10,7 @@ interface IEmailExistResponse {
 }
 
 const RegisterPage: React.FC = () => {
-  const navigation = useNavigate();
+  useNavigate();
 
   const [formValue, setformValue] = React.useState({
     email: '',
@@ -26,7 +26,6 @@ const RegisterPage: React.FC = () => {
   type IInputType = 'email' | 'password' | 'passwordCheck' | 'name';
 
   const handleChange = (event: React.BaseSyntheticEvent) => {
-    
     const inputType = event.target.name as IInputType;
     const inputValue = event.target.value;
 
@@ -41,10 +40,10 @@ const RegisterPage: React.FC = () => {
         break;
       case 'password':
         setPasswordValidState(regexUtil.isValidPassword(inputValue));
-        setPasswordCheckValidState(inputValue === formValue.passwordCheck)
+        setPasswordCheckValidState(inputValue === formValue.passwordCheck);
         break;
       case 'passwordCheck':
-        setPasswordCheckValidState(formValue.password === inputValue)
+        setPasswordCheckValidState(formValue.password === inputValue);
         break;
       case 'name':
         break;
@@ -76,9 +75,9 @@ const RegisterPage: React.FC = () => {
   return (
     <Grid2 container justifyContent={'center'}>
       <Grid2 xs={6}>
-        <Card style={CardStyle}>
+        <Box style={CardStyle}>
           <Typography component="h1" variant="h5">
-            Register
+            Readable
           </Typography>
           <Box component={'form'} onSubmit={handleSubmit} onChange={handleChange}>
             <TextField
@@ -94,6 +93,7 @@ const RegisterPage: React.FC = () => {
               error={!emailValidState || emailExistState}
               onBlur={handleEmailBlur}
               helperText={emailErrorMessage()}
+              variant="standard"
             />
             <TextField
               margin="normal"
@@ -102,6 +102,7 @@ const RegisterPage: React.FC = () => {
               id="name"
               label="Name"
               name="name"
+              variant="standard"
             />
             <TextField
               margin="normal"
@@ -112,7 +113,12 @@ const RegisterPage: React.FC = () => {
               name="password"
               type="password"
               error={!passwordValidState}
-              helperText={passwordValidState ? '' : '비밀번호는 영문 대문자, 소문자, 숫자를 포함하여 8 ~ 20 자리로 설정해주세요.'}
+              helperText={
+                passwordValidState
+                  ? ''
+                  : '비밀번호는 영문 대문자, 소문자, 숫자를 포함하여 8 ~ 20 자리로 설정해주세요.'
+              }
+              variant="standard"
             />
             <TextField
               margin="normal"
@@ -124,12 +130,15 @@ const RegisterPage: React.FC = () => {
               type="password"
               error={!passwordCheckValidState}
               helperText={passwordCheckValidState ? '' : '비밀번호가 일치하지 않습니다.'}
+              variant="standard"
             />
-            <Button type="submit" fullWidth variant="contained" sx={{ mt: 3, mb: 2 }}>
-              Register
-            </Button>
+            <Box display="flex" justifyContent="flex-end">
+              <Button type="submit" variant="contained" sx={{ mt: 3, mb: 2 }} size="large">
+                Register
+              </Button>
+            </Box>
           </Box>
-        </Card>
+        </Box>
       </Grid2>
     </Grid2>
   );


### PR DESCRIPTION
**개발 사항**
* 회원가입 화면 UI 수정
  * 카드 디자인이 구려서 Card => Box 로 교체 
  * 인풋 박스들 보더 속성 수정
  * 회원가입 버튼 크기 수정 및 우측 정렬
* cssBaseLine 설정
  * 각 html, body의 크기가 전체 화면이 되도록 수정 => overflow 등의 문제때문에 이전에는 이렇게 했었는데 적용해도 될지?
* 테마 설정
  * 테마 컬러를 설정하는 코드를 추가했습니다. 색상을 조합해보고 싶었는데 저의 미적감각이.....
  
**변경된 회원가입 화면**
<img width="1440" alt="스크린샷 2022-08-27 오전 11 40 51" src="https://user-images.githubusercontent.com/31911135/187011161-8181e847-7ecb-4a38-a4e7-f9149b6a6088.png">
